### PR TITLE
[Feature] Add drag reorder index information to OnAccept

### DIFF
--- a/lib/src/reorderable_staggered_scroll_view.dart
+++ b/lib/src/reorderable_staggered_scroll_view.dart
@@ -138,11 +138,11 @@ class ReorderableStaggeredScrollView extends StatefulWidget {
 
   /// A callback when an item is accepted during a drag operation.
   final void Function(ReorderableStaggeredScrollViewListItem?,
-      ReorderableStaggeredScrollViewListItem, bool)? onAccept;
+      ReorderableStaggeredScrollViewListItem, bool, {AcceptDetails? acceptDetails})? onAccept;
 
   /// A callback to check if an item will be accepted during a drag operation.
   final bool Function(ReorderableStaggeredScrollViewListItem?,
-      ReorderableStaggeredScrollViewListItem, bool)? onWillAccept;
+      ReorderableStaggeredScrollViewListItem, bool, {AcceptDetails? acceptDetails})? onWillAccept;
 
   /// A callback when an item leaves the target area during a drag operation.
   final void Function(ReorderableStaggeredScrollViewListItem?,
@@ -293,10 +293,10 @@ class ReorderableStaggeredScrollView extends StatefulWidget {
     Widget Function(ReorderableStaggeredScrollViewGridItem, Widget, Size)?
         buildFeedback,
     void Function(ReorderableStaggeredScrollViewGridItem?,
-            ReorderableStaggeredScrollViewGridItem, bool)?
+            ReorderableStaggeredScrollViewGridItem, bool, {AcceptDetails? acceptDetails})?
         onAccept,
     bool Function(ReorderableStaggeredScrollViewGridItem?,
-            ReorderableStaggeredScrollViewGridItem, bool)?
+            ReorderableStaggeredScrollViewGridItem, bool, {AcceptDetails? acceptDetails})?
         onWillAccept,
     void Function(ReorderableStaggeredScrollViewGridItem?,
             ReorderableStaggeredScrollViewGridItem, bool)?
@@ -333,11 +333,13 @@ class ReorderableStaggeredScrollView extends StatefulWidget {
             ? null
             : (ReorderableStaggeredScrollViewListItem? item1,
                     ReorderableStaggeredScrollViewListItem? item2,
-                    bool value) =>
+                    bool value,
+                    {AcceptDetails? acceptDetails}) =>
                 onAccept(
                   item1 as ReorderableStaggeredScrollViewGridItem?,
                   item2 as ReorderableStaggeredScrollViewGridItem,
                   value,
+                  acceptDetails: acceptDetails,
                 )),
         onLeave = (onLeave == null
             ? null
@@ -353,11 +355,13 @@ class ReorderableStaggeredScrollView extends StatefulWidget {
             ? null
             : (ReorderableStaggeredScrollViewListItem? item1,
                     ReorderableStaggeredScrollViewListItem? item2,
-                    bool value) =>
+                    bool value,
+                    {AcceptDetails? acceptDetails}) =>
                 onWillAccept(
                   item1 as ReorderableStaggeredScrollViewGridItem?,
                   item2 as ReorderableStaggeredScrollViewGridItem,
                   value,
+                  acceptDetails: acceptDetails,
                 )),
         onMove = (onMove == null
             ? null


### PR DESCRIPTION
This is kind of related to #2, though I didn't fully understand what they were trying to do.

I've added an AcceptDetails class that contains the old index, and the new index, of the reordered data on OnWillAccept and OnAccept. This lets users allow their own list to track changes, for example:


```dart
ReorderableStaggeredScrollView.grid(
          crossAxisCount: 4,
          onAccept: (item1, item2, value, {AcceptDetails? acceptDetails}) {
            print("Moved From: ${acceptDetails?.oldIndex} To ${acceptDetails?.newIndex}");
            if (acceptDetails != null) {
              setState(() {
                final shifted = cards.removeAt(acceptDetails.oldIndex);
                cards.insert(acceptDetails.newIndex, shifted);
              });
            }
          },
          children: _gridItems,
        );
      })
```

The core of this is the `AcceptDetails` class:

```dart
class AcceptDetails {
  /// The previous index an item was located at
  final int oldIndex;

  /// The new index an item was relocated to
  final int newIndex;

  const AcceptDetails({required this.oldIndex, required this.newIndex});
}
```

A field of this type is added to the `_DragContainerState`, which keeps track of where this item is being pulled and pushed to:

```dart
class _DragContainerState<T extends ReorderableStaggeredScrollViewListItem> extends State<DragContainer> {
  [...]
  int? originalindex;
  AcceptDetails? acceptDetails;
  [...]
}
```

This field is reset at the same time as `endWillAccept()`, and is set during `setWillAccept()` in the non-null moveData case.

Additionally, an `originalIndex` field is added, which helps keep track of final moves, otherwise I found I was unintentionally tracking all potential accepts as well, which wasn't what I wanted. OriginalIndex is updated in the `setDragStart` method.

I'd be happy to talk about better implementations, this is just what I'm working with in my own fork, I tried to keep the changes minimal, especially with modifying the public API, but if you were willing to change it a bit, then I think we could probably get better function signatures if you wanted.